### PR TITLE
Fixed testRefreshControl()

### DIFF
--- a/UITests/UITests.swift
+++ b/UITests/UITests.swift
@@ -14,7 +14,7 @@ class UITests: UITestCase {
 
         let firstCell = app.staticTexts["Adrienne"]
         let coordinate = firstCell.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
-        let bottom = firstCell.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 6))
+        let bottom = firstCell.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 10))
         coordinate.press(forDuration: 0, thenDragTo: bottom)
 
         app.buttons["Dismiss"].tap()


### PR DESCRIPTION
#15 This is done by adding more offset to the drag position. This makes app to drag table more to the bottom which then makes progress disappear. Progress was blocking UI thread thus making lock state.